### PR TITLE
fix: get rid of structuredClone errors

### DIFF
--- a/pages/browse.tsx
+++ b/pages/browse.tsx
@@ -43,9 +43,7 @@ export default function Paste() {
             icon: <IconX size={20} />,
           });
         } else {
-          let newLatest = structuredClone(latest);
-          newLatest = data;
-          setLatest(newLatest);
+          setLatest(data);
           setLoadLatest(true);
         }
       });

--- a/pages/info.tsx
+++ b/pages/info.tsx
@@ -43,9 +43,7 @@ export default function Paste() {
             icon: <IconX size={20} />,
           });
         } else {
-          let newLatest = structuredClone(latest);
-          newLatest = data;
-          setLatest(newLatest);
+          setLatest(data);
           setLoadLatest(true);
         }
       });

--- a/pages/p/[slug].tsx
+++ b/pages/p/[slug].tsx
@@ -72,17 +72,11 @@ export default function Paste() {
             icon: <IconX size={20} />,
           });
         } else {
-          let newPaste = structuredClone(paste);
-          newPaste = data;
+          const newPaste = {
+            ...data,
+            programmingLanguage: (data.programmingLanguage === 'csharp' ? 'c' : data.programmingLanguage) ?? 'tsx',
+          };
 
-          newPaste.programmingLanguage = newPaste.programmingLanguage
-
-            ? newPaste.programmingLanguage
-            : 'tsx';
-
-          newPaste.programmingLanguage =
-
-            newPaste.programmingLanguage === 'csharp' ? 'c' : newPaste.programmingLanguage;
           setPaste(newPaste);
           setPasteFound(true);
         }
@@ -100,9 +94,7 @@ export default function Paste() {
             icon: <IconX size={20} />,
           });
         } else {
-          let newLatest = structuredClone(latest);
-          newLatest = data;
-          setLatest(newLatest);
+          setLatest(data);
           setLoadLatest(true);
         }
       });


### PR DESCRIPTION
These errors are now gone:
![image](https://user-images.githubusercontent.com/38920928/196442743-1660a46b-7938-4e0e-af18-185447a38f47.png)
