### PR TITLE
fix: remove visible semicolon from UI

### DIFF
--- a/pages/p/[slug].tsx
+++ b/pages/p/[slug].tsx
@@ -179,7 +179,7 @@ export default function Paste() {
     <>
       {/* @ts-ignore */}
       <HeaderMenu links={links} />
-      <LoadingOverlay visible={!pasteFound} overlayBlur={5} />;
+      <LoadingOverlay visible={!pasteFound} overlayBlur={5} />
       <Page />
     </>
   );


### PR DESCRIPTION
Removes this semicolon:
![image](https://user-images.githubusercontent.com/38920928/196450501-87d2cca5-c08c-4790-b371-b09b0f81343c.png)
